### PR TITLE
adjusted color of citations to fit into the theme

### DIFF
--- a/Thesis/stuff/header.tex
+++ b/Thesis/stuff/header.tex
@@ -72,6 +72,7 @@
     , linkcolor=darkblue
     , menucolor=darkblue
     , urlcolor=darkblue
+    , citecolor=darkblue
     , pdftitle={\projname -- \untertitel}
     , pdfsubject={\thesisname}
     , pdfauthor={\authorname}


### PR DESCRIPTION
I changed the color of citations to be dark blue instead of the default neon green. 
In my opinion this new color fits the FH-Wedel theme of the document much better.