### PR TITLE
replaced scrpage2 (obsolete) with scrlayer-scrpage

### DIFF
--- a/Thesis/stuff/header.tex
+++ b/Thesis/stuff/header.tex
@@ -34,7 +34,7 @@
 %\usepackage[english]{babel}
 \usepackage[ngerman]{babel}
 \usepackage[T1]{fontenc}
-\usepackage[automark]{scrpage2} 	 % Schickerer Satzspiegel mit KOMA-Script
+\usepackage[automark]{scrlayer-scrpage} 	 % Schickerer Satzspiegel mit KOMA-Script
 \usepackage{setspace}           	 % Allow the modification of the space between lines
 \usepackage{booktabs}           	 % Netteres Tabellenlayout
 \usepackage{multicol}               % Mehrspaltige Bereiche


### PR DESCRIPTION
I replaced scrpage2 which is obsolete with scrlayer-scrpage. Interfaces are roughly the same. [http://tex.tips/scrpage2-is-obsolete/](url)