### PR TITLE
Entfernen von unnötiger \usepackage Option für "graphicx"

### DIFF
--- a/Thesis/stuff/header.tex
+++ b/Thesis/stuff/header.tex
@@ -32,7 +32,7 @@
 \ifpdf
   \usepackage{ae}               % Fonts für pdfLaTeX, falls keine cm-super-Fonts installiert
   \usepackage{microtype}        % optischer Randausgleich, falls pdflatex verwandt
-  \usepackage[pdftex]{graphicx} % Grafiken in pdfLaTeX
+  \usepackage{graphicx} % Grafiken in pdfLaTeX
 \else
   \usepackage[dvips]{graphicx}  % Grafiken und normales LaTeX
 \fi


### PR DESCRIPTION
"pdftex" ist die Standardoption beim Hinzufügen des Pakets "graphicx" und sollte deswegen nicht explizit gesetzt werden. Das explizite setzen hatte bei mir zu einem Latex Fehler geführt.

<img width="640" alt="image" src="https://github.com/fh-wedel/thesis-template/assets/11618226/6d767dce-7a53-4949-ab9f-d476ce490fd2">
